### PR TITLE
Add rename iterations_answers migration

### DIFF
--- a/app/controllers/api/iterations_controller.rb
+++ b/app/controllers/api/iterations_controller.rb
@@ -2,16 +2,29 @@
 
 module Api
   class IterationsController < BaseController
+    before_action :set_user, only: %i[index create]
+
+    def index
+      if @user
+        render json: @user.iterations
+      else
+        render json: 'Not user provided', status: :not_found
+      end
+    end
+
     def create
-      user = User.find_by(slug: post_params[:slug])
-      if user
-        user.iteration.create
+      if @user
+        @user.iteration.create
       else
         render json: 'Invalid user', status: :not_found
       end
     end
 
     private
+
+    def set_user
+      @user = User.find_by(slug: post_params[:slug])
+    end
 
     def post_params
       params.permit(:slug)

--- a/app/controllers/api/iterations_controller.rb
+++ b/app/controllers/api/iterations_controller.rb
@@ -4,6 +4,11 @@ module Api
   class IterationsController < BaseController
     before_action :require_current_user
 
+    # get all current user's iterations
+    def index
+      render json: current_user.iterations
+    end
+
     def show
       @iteration = current_user.iterations.find(params[:id])
       render json: @iteration

--- a/app/javascript/models/User.js
+++ b/app/javascript/models/User.js
@@ -1,5 +1,5 @@
 class User {
-    static show(slug, success, error = Function()) {
+    static show(success, error = Function()) {
         return axios.get(this.url() + '/me')
             .then(({data}) => success(data))
             .catch(

--- a/app/javascript/views/Home.vue
+++ b/app/javascript/views/Home.vue
@@ -19,7 +19,7 @@
             }
         }, methods: {
             getUser() {
-                User.show(this.$route.params.user_slug, (data) => {
+                User.show((data) => {
                     this.user = data
                 });
             }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     end
     resources :answers, only: [:create]
     resources :questions, only: [:show]
-    resources :iterations, only: %i[show create]
+    resources :iterations, only: %i[index show create]
   end
 
   # entry point for the vue.js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     resources :users, only: [:show]
     resources :answers, only: [:create]
     resources :questions, only: [:show]
+    resources :iterations, only: %i[index create]
   end
 
   # entry point for the vue.js

--- a/db/migrate/20191128084846_create_iterations_answers.rb
+++ b/db/migrate/20191128084846_create_iterations_answers.rb
@@ -1,6 +1,6 @@
 class CreateIterationsAnswers < ActiveRecord::Migration[6.0]
   def change
-    create_table :iteration_answers do |t|
+    create_table :iterations_answers do |t|
       t.references :iteration, null: false, foreign_key: true
       t.references :question, null: false, foreign_key: true
       t.references :answer, null: false, foreign_key: true

--- a/db/migrate/20191202135548_rename_iterations_answers.rb
+++ b/db/migrate/20191202135548_rename_iterations_answers.rb
@@ -1,0 +1,5 @@
+class RenameIterationsAnswers < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :iterations_answers, :iteration_answers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_02_085346) do
+ActiveRecord::Schema.define(version: 2019_12_02_135548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,21 +27,21 @@ ActiveRecord::Schema.define(version: 2019_12_02_085346) do
     t.index ["question_id"], name: "index_answers_on_question_id"
   end
 
+  create_table "iteration_answers", force: :cascade do |t|
+    t.bigint "iteration_id", null: false
+    t.bigint "question_id", null: false
+    t.bigint "answer_id", null: false
+    t.string "value"
+    t.index ["answer_id"], name: "index_iteration_answers_on_answer_id"
+    t.index ["iteration_id"], name: "index_iteration_answers_on_iteration_id"
+    t.index ["question_id"], name: "index_iteration_answers_on_question_id"
+  end
+
   create_table "iterations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_iterations_on_user_id"
-  end
-
-  create_table "iterations_answers", force: :cascade do |t|
-    t.bigint "iteration_id", null: false
-    t.bigint "question_id", null: false
-    t.bigint "answer_id", null: false
-    t.string "value"
-    t.index ["answer_id"], name: "index_iterations_answers_on_answer_id"
-    t.index ["iteration_id"], name: "index_iterations_answers_on_iteration_id"
-    t.index ["question_id"], name: "index_iterations_answers_on_question_id"
   end
 
   create_table "questions", force: :cascade do |t|
@@ -73,9 +73,9 @@ ActiveRecord::Schema.define(version: 2019_12_02_085346) do
 
   add_foreign_key "answers", "questions"
   add_foreign_key "answers", "questions", column: "next_question_id"
+  add_foreign_key "iteration_answers", "answers"
+  add_foreign_key "iteration_answers", "iterations"
+  add_foreign_key "iteration_answers", "questions"
   add_foreign_key "iterations", "users"
-  add_foreign_key "iterations_answers", "answers"
-  add_foreign_key "iterations_answers", "iterations"
-  add_foreign_key "iterations_answers", "questions"
   add_foreign_key "recommendations", "answers"
 end


### PR DESCRIPTION
Added the migration that will rename the table from `iterations_answers` to `iteration_answers`. it was previously address in #12. but it was preventing migration and we had to run `rails db:reset` to access the changes