### PR TITLE
Fix completion rate method

### DIFF
--- a/app/models/iteration.rb
+++ b/app/models/iteration.rb
@@ -19,7 +19,7 @@ class Iteration < ApplicationRecord
   end
 
   def completion_rate
-    (questions.count.to_f / Question.count * 100).to_i
+    (questions.distinct.count.to_f / Question.count * 100).to_i
   end
 
   def as_json(args = {})


### PR DESCRIPTION
Fixed the completion rate by only counting the distinct questions instead of all questions
which was causing the issue in case of multiple answer for the same question and result in a
rate above a 100%