### PR TITLE
Add scoping to user email forms

### DIFF
--- a/app/controllers/api/iterations_controller.rb
+++ b/app/controllers/api/iterations_controller.rb
@@ -27,14 +27,14 @@ module Api
         current_iteration.notify_completion
         render json: 'Success', status: :ok
       else
-        render status: :unprocessable_entity
+        render json: current_user.errors, status: :unprocessable_entity
       end
     end
 
     private
 
     def user_params
-      params.permit(:email)
+      params.require(:user).permit(:email)
     end
   end
 end

--- a/app/javascript/component/form/UserEmail.vue
+++ b/app/javascript/component/form/UserEmail.vue
@@ -46,7 +46,7 @@ export default {
     return {
       form: new Form({
         email: ''
-      }),
+      }, 'user'),
       submitted: false,
     }
   },

--- a/app/javascript/utilities/Form.js
+++ b/app/javascript/utilities/Form.js
@@ -8,8 +8,9 @@ export default class Form {
      *
      * @param {object} data
      */
-  constructor(data) {
+  constructor(data, scope) {
     this.originalData = data;
+    this.scope = scope;
 
     for (let field in data) {
       this[field] = data[field];
@@ -28,7 +29,13 @@ export default class Form {
     for (let property in this.originalData) {
       data[property] = this[property];
     }
-
+    // if a scope is set, we nest the data
+    if (this.scope) {
+      let scoped = {};
+      scoped[this.scope] = data
+      data = scoped;
+    }
+    console.log(data);
     return data;
   }
 


### PR DESCRIPTION
For the rails API side it is nicer and a default form convention to
scope the form parameters under.

e.g. user[email]