### PR TITLE
Add a single fontawesome css file

### DIFF
--- a/app/views/layouts/spa.html.erb
+++ b/app/views/layouts/spa.html.erb
@@ -11,7 +11,8 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'app' %>
-    <script src="https://kit.fontawesome.com/9378dbb6ae.js" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css"
+        integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous">
 </head>
 <body>
 </body>


### PR DESCRIPTION
Added a single line to retrieve the css file instead of using
a script which loads multiple files.

Closes #136